### PR TITLE
Bugfix - Ensure to unmarshall keys in query's read method

### DIFF
--- a/lib/queries.js
+++ b/lib/queries.js
@@ -193,7 +193,10 @@ module.exports = cache => {
                 });
             }
 
-            return resultCached;
+            return [
+              unMarshalKeys(resultCached[0]),
+              resultCached[1]
+            ];
         }
     };
 


### PR DESCRIPTION
When trying to use the cache in https://github.com/sebelga/gstore-node, I noticed that in certain cases I'd get the following error:
```
TypeError: Cannot read property 'path' of undefined
    at idFromKey (node_modules/gstore-node/lib/serializers/datastore.js:112:24)
    at Function.convertToJson (node_modules/gstore-node/lib/serializers/datastore.js:85:17)
    at Function.fromDatastore (node_modules/gstore-node/lib/serializers/datastore.js:72:34)
    at entities.map.entity (node_modules/gstore-node/lib/query.js:54:55)
    at Array.map (<anonymous>)
    at onQuery (node_modules/gstore-node/lib/query.js:53:37)

    at tryCatcher (node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (node_modules/bluebird/js/release/promise.js:693:18)
    at Async._drainQueue (node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:785:20)
    at tryOnImmediate (timers.js:747:5)
```

This seems to suggest that redis cache was returning a and entity which did not have a symbol, and indeed it was.

I'm not 100% certain on the fix, as I've only adopted it to response formats I've seen in my usage, but I'm happy to update this to a better solution or maybe a method that I should use to unmarshall keys in query results.