### PR TITLE
fix: Add keys to entities after reading from cache

### DIFF
--- a/lib/keys.js
+++ b/lib/keys.js
@@ -87,7 +87,8 @@ module.exports = cache => {
             .then(onResult);
 
         function onResult(_cacheResult) {
-            const cacheResult = arrify(_cacheResult).filter(r => r !== undefined && r !== null);
+            const entitiesWithKeys = addKeyToEntity(arrify(_cacheResult), keys);
+            const cacheResult = entitiesWithKeys.filter(r => r !== undefined && r !== null);
             const isEmptyResult = cacheResult.length === 0;
 
             if (isEmptyResult) {


### PR DESCRIPTION
This PR fixes an issue on gstore-node (https://github.com/sebelga/gstore-node/issues/187)