### PR TITLE
fix: custom config undefined on init

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ class NsqlCache {
 
     init(settings = {}) {
         const self = this;
-        let { config } = settings;
+        let config = settings;
         config = config || {};
 
         // make a copy before merging the config into the defaultConfig


### PR DESCRIPTION
custom settings for certain variables (i.e. hashCacheKeys) are not used, as config ends up undefined before overwriting default options.

workaround for #7 